### PR TITLE
feat: Display item order correctly

### DIFF
--- a/examples/timeline/other/usingReact16.html
+++ b/examples/timeline/other/usingReact16.html
@@ -11,6 +11,24 @@
         width: 50vw;
         margin: 0 auto;
       }
+
+      .added-section {
+        display: flex;
+        align-items: center;
+        height: 40px;
+      }
+
+      .added-section input {
+        width: 50px;
+        margin: 0 0.5rem;
+      }
+
+      .added-section button {
+        height : 20px;
+        margin-left: 1rem;
+
+      }
+
       .vis-item.vis-range {
         border: none !important;
         background: transparent !important;
@@ -125,9 +143,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
 
     <!-- for watch command -->
-    <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
+    <!-- <script src="../../../dist/vis-timeline-graph2d.min.js"></script> -->
     <!-- for build command -->
-    <!-- <script src="../../../standalone/umd/vis-timeline-graph2d.min.js"></script> -->
+    <script src="../../../standalone/umd/vis-timeline-graph2d.min.js"></script>
     <link
       href="../../../styles/vis-timeline-graph2d.css"
       rel="stylesheet"
@@ -135,6 +153,16 @@
     />
 
     <script type="text/babel">
+      window.groupDataSet = new vis.DataSet();
+      window.itemDataSet = new vis.DataSet();
+
+      const DISPLAY_STATUS_MAP = {
+        0: "not_check_in",
+        1: "check_in",
+        8: "confirmed",
+        9: "finished",
+      };
+
       function setTime(payload = { hour: 0, minute: 0 }) {
         return moment()
           .set({ ...payload, second: 0 })
@@ -184,38 +212,87 @@
        * 3. 同樣的時間長度、開始時間，如果是暫停時間 (occu_type === 0) 就排在前面
        * 4. 同樣的時間長度、開始時間、都是訂單(occu_type === 1)，則根據訂單建立時間 (order_created_at) 排序，越早建立的在越前面
        *  */
-      function sortSlots(slots) {
-        return slots.sort((a, b) => {
-          const aDuration =
-            new Date(a.end).getTime() - new Date(a.start).getTime();
-          const bDuration =
-            new Date(b.end).getTime() - new Date(b.start).getTime();
+      function sortSlots(a, b) {
+        const aDuration =
+          new Date(a.end).getTime() - new Date(a.start).getTime();
+        const bDuration =
+          new Date(b.end).getTime() - new Date(b.start).getTime();
 
-          return (
-            bDuration - aDuration ||
-            new Date(a.start).getTime() - new Date(b.start).getTime() ||
-            (isTimePauseSlot(b) ? 1 : 0) ||
-            new Date(a.order_created_at).getTime() -
-              new Date(b.order_created_at).getTime()
-          );
+        return (
+          bDuration - aDuration ||
+          new Date(a.start).getTime() - new Date(b.start).getTime() ||
+          // (isTimePauseSlot(b) ? 1 : 0) ||
+          new Date(a.order_created_at).getTime() -
+            new Date(b.order_created_at).getTime()
+        );
+      }
+
+      function generateOverlapItem(amount = 96, duration = 60) {
+        const offsetMinute = 15;
+        const groupAmount = duration / offsetMinute;
+        return Array.from({ length: amount }, (_, index) => {
+          const startHour = Math.floor(index / groupAmount);
+          const startMinutes = (index % groupAmount) * offsetMinute;
+          const start = setTime({ hour: startHour, minute: startMinutes });
+          const end = setTime({
+            hour: startHour,
+            minute: startMinutes + duration,
+          });
+          const status =
+            Object.keys(DISPLAY_STATUS_MAP)[
+              index % Object.keys(DISPLAY_STATUS_MAP).length
+            ];
+          return {
+            id: index,
+            order_created_at: "2023-10-04 09:44:07",
+            start,
+            end,
+            order_display_status: status,
+            cust_name: "Debby",
+            cust_title: "小姐",
+          };
         });
       }
 
-      const displayStatusMap = {
-        0: "not_check_in",
-        1: "check_in",
-        2: "cancel_refunded_all",
-        3: "cancel_refunded_seventy",
-        4: "cancel_refunded_partial",
-        5: "cancel_by_user",
-        6: "cancel_by_merchant",
-        7: "no_show",
-        8: "confirmed",
-        9: "finished",
-      };
+      function generateGroupWithOverlapItem(groupAmount = 1, itemAmount = 96) {
+        const groupDataSet = window.groupDataSet;
+        const itemDataSet = window.itemDataSet;
 
-      const mockItemList = [
+        const preGroupLength = groupDataSet.length || 0;
+
+        Array.from({ length: groupAmount }, (_, groupIndex) => {
+          const groupId = groupIndex + preGroupLength;
+
+          groupDataSet.add({
+            id: groupId,
+            content: `Room ${groupId}`,
+          });
+
+          generateOverlapItem(itemAmount)
+            .sort(sortSlots)
+            .forEach((item, index) => {
+              const newItemId = `${index}--${groupId}`;
+              const newItem = {
+                ...item,
+                id: newItemId,
+              };
+              itemDataSet.add({
+                group: groupId,
+                data: newItem,
+                ...newItem,
+              });
+            });
+        });
+
+        return {
+          groupDataSet,
+          itemDataSet,
+        };
+      }
+
+      const testData = [
         {
+          id: 0,
           order_id: 3191484087511,
           order_created_at: "2023-10-04 09:44:07",
           start: setTime({ hour: 10, minute: 0 }),
@@ -225,6 +302,7 @@
           cust_title: "小姐",
         },
         {
+          id: 1,
           order_id: 3191487353494,
           order_created_at: "2023-10-04 09:44:26",
           start: setTime({ hour: 10, minute: 15 }),
@@ -234,6 +312,7 @@
           cust_title: "小姐",
         },
         {
+          id: 2,
           order_id: 3191507404885,
           order_created_at: "2023-10-04 09:44:43",
           start: setTime({ hour: 10, minute: 45 }),
@@ -243,6 +322,7 @@
           cust_title: "小姐",
         },
         {
+          id: 3,
           order_id: 3191497164243,
           order_created_at: "2023-10-04 09:45:47",
           start: setTime({ hour: 11, minute: 15 }),
@@ -252,6 +332,7 @@
           cust_title: "小姐",
         },
         {
+          id: 4,
           order_id: 3191498472338,
           order_created_at: "2023-10-04 09:46:12",
           start: setTime({ hour: 11, minute: 0 }),
@@ -261,6 +342,7 @@
           cust_title: "小姐",
         },
         {
+          id: 5,
           order_id: 3191589533034,
           order_created_at: "2023-10-04 22:35:27",
           start: setTime({ hour: 11, minute: 0 }),
@@ -272,30 +354,7 @@
         },
       ];
 
-      // create groups
-      var numberOfGroups = 1;
-      var groups = new vis.DataSet();
-      for (var i = 0; i < numberOfGroups; i++) {
-        groups.add({
-          id: i,
-          content: "Unassigned",
-        });
-      }
-
-      // create items
-      const numberOfItems = 1000;
-      window.items = new vis.DataSet();
-
-      const sortedList = sortSlots([...mockItemList]);
-      sortedList.forEach((item, index) => {
-        items.add({
-          id: index,
-          group: 0,
-          content: `${index} ${item.cust_name} ${item.cust_title}`,
-          data: item,
-          ...item,
-        });
-      });
+      const { groupDataSet, itemDataSet } = generateGroupWithOverlapItem();
 
       var GroupTemplate = (group) => {
         const className = `group-container`;
@@ -313,7 +372,7 @@
         render() {
           const { content, start, end, data } = this.props.item;
           const className = `${
-            displayStatusMap[data.order_display_status]
+            DISPLAY_STATUS_MAP[data.order_display_status]
           } item-container`;
           return (
             <div className={className}>
@@ -379,7 +438,9 @@
           overrideItems: false, // allow these options to override item.editable
         },
         onInitialDrawComplete: () => {
-          window.timeline.setItems(window.items);
+          console.log("%conInitialDrawComplete", "color: #bada55");
+          window.timeline.setItems(itemDataSet);
+          console.timeEnd("timeline");
         },
         template: function (item, element) {
           if (!item) {
@@ -406,15 +467,71 @@
       };
 
       class Timeline extends React.Component {
+        constructor() {
+          super();
+          // 初始化狀態
+          this.state = {
+            groupAmount: 5,
+            itemAmount: 96,
+            isAddingGroup: false,
+          };
+        }
         componentDidMount() {
           return initTimeline();
         }
+
+        onGroupAmountChange(e) {
+          this.setState({
+            groupAmount: Number(e.target.value),
+          });
+        }
+
+        onItemAmountChange(e) {
+          this.setState({
+            itemAmount: Number(e.target.value),
+          });
+        }
+
+        onBtnClick() {
+          const { groupDataSet, itemDataSet } = generateGroupWithOverlapItem(
+            this.state.groupAmount,
+            this.state.itemAmount
+          );
+          this.setState({
+            isAddingGroup: true,
+          });
+          console.time("onBtnClick");
+          window.timeline.setGroups(groupDataSet);
+          window.timeline.setItems(itemDataSet);
+          this.setState({
+            isAddingGroup: false,
+          });
+          console.timeEnd("onBtnClick");
+        }
+
         render() {
           return (
             <div id="container">
-              <h1>timeline with React</h1>
-              <h2>Using react components for items and group templates</h2>
-
+              <h1>Timeline with React</h1>
+              {this.state.isAddingGroup && <h2> Adding group... </h2>}
+              <div className="added-section">
+                <h3>
+                  <span> Add </span>
+                  <input
+                    type="number"
+                    value={this.state.groupAmount}
+                    onChange={this.onGroupAmountChange.bind(this)}
+                  />
+                  <span>Group with </span>
+                  <input
+                    type="number"
+                    value={this.state.itemAmount}
+                    onChange={this.onItemAmountChange.bind(this)}
+                  />
+                  <span> Items </span>
+                </h3>
+                <button onClick={() => this.onBtnClick()}> Add group </button>
+              </div>
               <div id="visualization"></div>
             </div>
           );
@@ -423,7 +540,12 @@
 
       function initTimeline() {
         var container = document.getElementById("visualization");
-        window.timeline = new vis.Timeline(container, items, groups, options);
+        window.timeline = new vis.Timeline(
+          container,
+          [],
+          groupDataSet,
+          options
+        );
       }
 
       ReactDOM.render(<Timeline />, document.getElementById("root"));

--- a/examples/timeline/other/usingReact16.html
+++ b/examples/timeline/other/usingReact16.html
@@ -1,151 +1,432 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Timeline | other | React 16 Components in templates</title>
 
     <meta name="example-screenshot-selector" content="#root" />
 
     <style>
-        .vis-item-visible-frame {
-            z-index: 111111;
-            position: absolute;
-            top: 0;
-        }
+      #container {
+        width: 50vw;
+        margin: 0 auto;
+      }
+      .vis-item.vis-range {
+        border: none !important;
+        background: transparent !important;
+        box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.1);
+      }
+      .vis-item.vis-range > .vis-item-overflow {
+        padding: 8px 0 0 8px;
+        margin: -8px 0 0 -8px;
+        box-sizing: content-box;
+        pointer-events: none;
+
+        border-radius: 4px;
+        border-top-right-radius: 14%;
+
+      }
+      .vis-item.vis-range > .vis-item-content {
+        padding: 0;
+        width: 100%;
+      }
+
+      .vis-item.vis-range.vis-selected {
+        box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.3);
+      }
+
+      .vis-item-visible-frame {
+        z-index: 111111;
+        position: absolute;
+        top: 0;
+      }
+      .group-container,.item-container {
+        height: 80px;
+      }
+      .group-container {
+
+      }
+      .item-container {
+        padding-top: 0.125rem;
+        padding-bottom: 0.125rem;
+        position: relative;
+        cursor: pointer;
+        font-size: 0.875rem;
+        line-height: 1.25rem;
+        box-sizing: border-box;
+        width: 100%;
+        border-radius: 0.25rem;
+        box-sizing: border-box;
+      }
+
+      /* TimelineItem */
+      .item-container__content {
+        height: 95%;
+        max-height: 95%;
+        padding: 0.125rem;
+        display: flex;
+        flex-wrap: wrap;
+
+        align-items: center;
+        width: 100%;
+        overflow: hidden;
+        font-size: 16px;
+        line-height: 16px;
+        box-sizing: box-sizing: border-box;
+
+      }
+      .unavailable {
+            background-color: #c03f45;
+            color: #fff;
+      }
+        /* transform above windicss flag to normal css */
+
+      .overBooked-icon {
+        transform: translateX(-50%) translateY(-50%);
+        position: absolute;
+        top: 0;
+        left: 0;
+        background-color: #ff5537;
+        color: #fff;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        text-align: center;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .not_check_in {
+        background: #a7d1c3;
+        color: #3b7260;
+      }
+      .check_in {
+        background: #4d947c;
+        color: white;
+      }
+
+      .confirmed {
+        background: #e2edf1;
+        color: #5b9cb3;
+      }
+      .finished {
+        background: #468196;
+        color: white;
+      }
     </style>
   </head>
   <body>
+    <div id="root"></div>
 
-    <div id='root'></div>
-    
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.4.2/umd/react.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.4.2/umd/react-dom.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.5.1/umd/react-dom-server.browser.development.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
 
-    <script src="../../../standalone/umd/vis-timeline-graph2d.min.js"></script>
-    <link href="../../../styles/vis-timeline-graph2d.css" rel="stylesheet" type="text/css" />
-    
+    <!-- for watch command -->
+    <script src="../../../dist/vis-timeline-graph2d.min.js"></script>
+    <!-- for build command -->
+    <!-- <script src="../../../standalone/umd/vis-timeline-graph2d.min.js"></script> -->
+    <link
+      href="../../../styles/vis-timeline-graph2d.css"
+      rel="stylesheet"
+      type="text/css"
+    />
 
     <script type="text/babel">
-        // create groups
-        var numberOfGroups = 25; 
-        var groups = new vis.DataSet()
-        for (var i = 0; i < numberOfGroups; i++) {
-            groups.add({
-              id: i,
-              content: 'Truck ' + i
-            })
-        }
-          
-        // create items
-        var numberOfItems = 1000;
-        window.items = new vis.DataSet();
-        var itemsPerGroup = Math.round(numberOfItems/numberOfGroups);
-        for (var truck = 0; truck < numberOfGroups; truck++) {
-            var date = new Date();
-            for (var order = 0; order < itemsPerGroup; order++) {
-              date.setHours(date.getHours() +  4 * (Math.random() < 0.2));
-              var start = new Date(date);
-              date.setHours(date.getHours() + 2 + Math.floor(Math.random()*4));
-              var end = new Date(date);
-              items.add({
-                id: order + itemsPerGroup * truck,
-                group: truck,
-                start: start,
-                end: end,
-                content: 'Order ' + order
-              });
-            }
-        }
+      function setTime(payload = { hour: 0, minute: 0 }) {
+        return moment()
+          .set({ ...payload, second: 0 })
+          .format("YYYY-MM-DD HH:mm:ss");
+      }
 
-        var GroupTemplate = (group) => {
-            return <div>
-                <label>{group.content}</label>
-            </div>
-        }
+      // 讓 vis-timeline 時間軸預設寬度在 tablet 和 desktop 至少 > 40px
+      function getTodayTimelineStartAndEndByDeviceWidth(date = moment()) {
+        // 根據 Spec，選擇 今日 時，Focus 在當下時間點 往前推 2 hr 整點 的位置，
+        const initStartTime = moment(date).hours(8);
+        const endOfDay = moment(date).endOf("day");
+        const hourRange = 6;
+        const rangeBetweenNowAndEndOfDay = endOfDay.diff(
+          initStartTime,
+          "hours"
+        );
 
-        class ItemTemplate extends React.Component {
-            constructor(props){
-                super(props);
-            }
-            render() {
-                return <div>
-                    <label>{this.props.item.content}</label>
-                    <button onClick={()=> { return console.log('aaaaaa')}}>aaaa</button>
-                </div>
-            }
-        }
+        const start =
+          rangeBetweenNowAndEndOfDay < hourRange
+            ? moment(initStartTime).subtract(
+                hourRange - rangeBetweenNowAndEndOfDay,
+                "h"
+              )
+            : initStartTime;
+        const end =
+          rangeBetweenNowAndEndOfDay < hourRange
+            ? endOfDay
+            : moment(initStartTime).add(hourRange, "h");
 
-        class VisibleFramTemplate extends React.Component {
-            constructor(props){
-                super(props);
-            }
-            render() {
-                return <div>
-                    id: {this.props.item.id}
-                    <button onClick={()=> { return console.log('aaaaaa') }}>aaaa</button>
-                </div>
-            }
-        }
-
-        // specify options
-        var options = {
-            orientation: 'top',
-            maxHeight: 400,
-            start: new Date(),
-            end: new Date(1000*60*60*24 + (new Date()).valueOf()),
-            editable: true,
-            onInitialDrawComplete: () => {
-                window.timeline.setItems(window.items)
-            },
-            template: function (item, element) {
-                if (!item) { return }                
-
-                return ReactDOM.createPortal( ReactDOM.render( <ItemTemplate item={item} />, element ), element, () => { window.timeline.redraw()} );
-                
-                // Works too
-                // return ReactDOMServer.renderToString(<ItemTemplate item={item} />)
-                
-                // Kinda works
-                // ReactDOM.render(<ItemTemplate item={item} />, element );
-                // return '' 
-            },
-           
-            groupTemplate: function (group, element) {
-                if (!group || !group.content) { return }
-                return ReactDOM.createPortal( ReactDOM.render( <GroupTemplate group={group} />, element ), element );
-            },
-
-            visibleFrameTemplate: function (item, element) {
-                if (!item || !element) { return }
-                if (element.className.indexOf('timeline-item-visible-frame') === -1) { return }
-                return ReactDOM.createPortal( ReactDOM.render( <VisibleFramTemplate item={item} />, element ), element );
-                
-            },
-        }
-    
-        class Timeline extends React.Component {
-            componentDidMount() {
-                return initTimeline();
-            }
-            render() {
-                return <div>
-                    <h1>timline with React</h1>
-                    <h2>Using react components for items and group templates</h2>      
-
-                    <div id="visualization"></div>
-                </div>
-            }
+        return {
+          start,
+          end,
+          range: hourRange,
         };
+      }
+      function isTimePauseSlot(slot) {
+        return (
+          !slot ||
+          ("occu_type" in slot && slot.occu_type === OccupationType.Unavailable)
+        );
+      }
 
-        function initTimeline() {
-            var container = document.getElementById('visualization');
-            window.timeline = new vis.Timeline(container, items, groups, options);
-        } 
+      /**
+       * 排序規則
+       * 1. 根據時間長度排序，越長的在越前面
+       * 2. 同樣的時間長度，根據開始時間排序，越早開始的在越前面
+       * 3. 同樣的時間長度、開始時間，如果是暫停時間 (occu_type === 0) 就排在前面
+       * 4. 同樣的時間長度、開始時間、都是訂單(occu_type === 1)，則根據訂單建立時間 (order_created_at) 排序，越早建立的在越前面
+       *  */
+      function sortSlots(slots) {
+        return slots.sort((a, b) => {
+          const aDuration =
+            new Date(a.end).getTime() - new Date(a.start).getTime();
+          const bDuration =
+            new Date(b.end).getTime() - new Date(b.start).getTime();
 
-        ReactDOM.render(<Timeline />, document.getElementById('root'));
+          return (
+            bDuration - aDuration ||
+            new Date(a.start).getTime() - new Date(b.start).getTime() ||
+            (isTimePauseSlot(b) ? 1 : 0) ||
+            new Date(a.order_created_at).getTime() -
+              new Date(b.order_created_at).getTime()
+          );
+        });
+      }
+
+      const displayStatusMap = {
+        0: "not_check_in",
+        1: "check_in",
+        2: "cancel_refunded_all",
+        3: "cancel_refunded_seventy",
+        4: "cancel_refunded_partial",
+        5: "cancel_by_user",
+        6: "cancel_by_merchant",
+        7: "no_show",
+        8: "confirmed",
+        9: "finished",
+      };
+
+      const mockItemList = [
+        {
+          order_id: 3191484087511,
+          order_created_at: "2023-10-04 09:44:07",
+          start: setTime({ hour: 10, minute: 0 }),
+          end: setTime({ hour: 11, minute: 0 }),
+          order_display_status: 0,
+          cust_name: "Debby test",
+          cust_title: "小姐",
+        },
+        {
+          order_id: 3191487353494,
+          order_created_at: "2023-10-04 09:44:26",
+          start: setTime({ hour: 10, minute: 15 }),
+          end: setTime({ hour: 11, minute: 15 }),
+          order_display_status: 9,
+          cust_name: "Debby test",
+          cust_title: "小姐",
+        },
+        {
+          order_id: 3191507404885,
+          order_created_at: "2023-10-04 09:44:43",
+          start: setTime({ hour: 10, minute: 45 }),
+          end: setTime({ hour: 11, minute: 45 }),
+          order_display_status: 1,
+          cust_name: "Debby test",
+          cust_title: "小姐",
+        },
+        {
+          order_id: 3191497164243,
+          order_created_at: "2023-10-04 09:45:47",
+          start: setTime({ hour: 11, minute: 15 }),
+          end: setTime({ hour: 12, minute: 15 }),
+          order_display_status: 0,
+          cust_name: "Debby test",
+          cust_title: "小姐",
+        },
+        {
+          order_id: 3191498472338,
+          order_created_at: "2023-10-04 09:46:12",
+          start: setTime({ hour: 11, minute: 0 }),
+          end: setTime({ hour: 12, minute: 0 }),
+          order_display_status: 8,
+          cust_name: "Debby test",
+          cust_title: "小姐",
+        },
+        {
+          order_id: 3191589533034,
+          order_created_at: "2023-10-04 22:35:27",
+          start: setTime({ hour: 11, minute: 0 }),
+          end: setTime({ hour: 12, minute: 0 }),
+
+          order_display_status: 0,
+          cust_name: "Debby test",
+          cust_title: "小姐",
+        },
+      ];
+
+      // create groups
+      var numberOfGroups = 1;
+      var groups = new vis.DataSet();
+      for (var i = 0; i < numberOfGroups; i++) {
+        groups.add({
+          id: i,
+          content: "Unassigned",
+        });
+      }
+
+      // create items
+      const numberOfItems = 1000;
+      window.items = new vis.DataSet();
+
+      const sortedList = sortSlots([...mockItemList]);
+      sortedList.forEach((item, index) => {
+        items.add({
+          id: index,
+          group: 0,
+          content: `${index} ${item.cust_name} ${item.cust_title}`,
+          data: item,
+          ...item,
+        });
+      });
+
+      var GroupTemplate = (group) => {
+        const className = `group-container`;
+        return (
+          <div className={className}>
+            <label>{group.group.content}</label>
+          </div>
+        );
+      };
+
+      class ItemTemplate extends React.Component {
+        constructor(props) {
+          super(props);
+        }
+        render() {
+          const { content, start, end, data } = this.props.item;
+          const className = `${
+            displayStatusMap[data.order_display_status]
+          } item-container`;
+          return (
+            <div className={className}>
+              <div className="item-container__content">
+                <div>{content}</div>
+                <div>{moment(start).format("HH:mm")}</div>
+              </div>
+            </div>
+          );
+        }
+      }
+
+      const selectedDate = moment().startOf("day");
+      const timelineStartAndEnd = getTodayTimelineStartAndEndByDeviceWidth(
+        moment()
+      );
+      // specify options
+      const options = {
+        showCurrentTime: false, // 隱藏 timeline 上的 current time，改為自己實作
+        // TODO：根據 API Order 決定 group 的順序
+        groupOrder: function (a, b) {
+          return a.orderIndex - b.orderIndex;
+        },
+        groupHeightMode: "fixed", // 避免該 row 沒有 item 時，高度會不一致
+        // showMajorLabels: false, // 如果設為 true，則會顯示當前日期的時間軸
+        stack: false, // 讓 item 可以互相重疊
+        verticalScroll: true,
+        horizontalScroll: true,
+        // 由於 timeline 會自動計算 cell 的寬度，為了滿足需求，所以這邊要自行使用 start/end 來計算 cell 的寬度
+        start: timelineStartAndEnd.start,
+        end: timelineStartAndEnd.end,
+        // 設下 min/max 邊界防止 timeline 無限滾動，以及設定 zoomable 為 false 防止使用者縮放
+        min: moment(selectedDate).startOf("day").valueOf(),
+        max: moment(selectedDate).endOf("day").valueOf(),
+        zoomable: false,
+        orientation: { axis: "top" },
+        margin: {
+          // item 有預設的 margin，這邊重新調整以符合設計
+          item: {
+            horizontal: 0,
+            vertical: 2,
+          },
+        },
+        timeAxis: { scale: "minute", step: 30 },
+        format: {
+          // 將 timeline 上的時間軸格式化
+          minorLabels: function (date, scale, step) {
+            switch (scale) {
+              case "minute":
+                return moment(date).minute() === 0
+                  ? `${moment(date).hour()}`
+                  : "";
+              default:
+                return new Date(date);
+            }
+          },
+        },
+        editable: {
+          add: false, // add new items by double tapping
+          updateTime: false, // drag items horizontally
+          updateGroup: false, // drag items from one group to another
+          remove: false, // delete an item by tapping the delete button top right
+          overrideItems: false, // allow these options to override item.editable
+        },
+        onInitialDrawComplete: () => {
+          window.timeline.setItems(window.items);
+        },
+        template: function (item, element) {
+          if (!item) {
+            return;
+          }
+
+          return ReactDOM.createPortal(
+            ReactDOM.render(<ItemTemplate item={item} />, element),
+            element,
+            () => {
+              window.timeline.redraw();
+            }
+          );
+        },
+        groupTemplate: function (group, element) {
+          if (!group || !group.content) {
+            return;
+          }
+          return ReactDOM.createPortal(
+            ReactDOM.render(<GroupTemplate group={group} />, element),
+            element
+          );
+        },
+      };
+
+      class Timeline extends React.Component {
+        componentDidMount() {
+          return initTimeline();
+        }
+        render() {
+          return (
+            <div id="container">
+              <h1>timeline with React</h1>
+              <h2>Using react components for items and group templates</h2>
+
+              <div id="visualization"></div>
+            </div>
+          );
+        }
+      }
+
+      function initTimeline() {
+        var container = document.getElementById("visualization");
+        window.timeline = new vis.Timeline(container, items, groups, options);
+      }
+
+      ReactDOM.render(<Timeline />, document.getElementById("root"));
     </script>
   </body>
 </html>

--- a/examples/timeline/other/usingReact16.html
+++ b/examples/timeline/other/usingReact16.html
@@ -8,7 +8,7 @@
 
     <style>
       #container {
-        width: 50vw;
+        width: 85vw;
         margin: 0 auto;
       }
 
@@ -76,16 +76,18 @@
         border-radius: 0.25rem;
         box-sizing: border-box;
       }
-
+      .vis-item-content {
+        width: 100%;
+      }
       /* TimelineItem */
       .item-container__content {
         height: 95%;
         max-height: 95%;
-        padding: 0.125rem;
+        padding: 0 0.5rem;
         display: flex;
-        flex-wrap: wrap;
-
-        align-items: center;
+        flex-direction: column;
+        justify-content: center;
+        align-items: start;
         width: 100%;
         overflow: hidden;
         font-size: 16px;
@@ -174,7 +176,7 @@
         // 根據 Spec，選擇 今日 時，Focus 在當下時間點 往前推 2 hr 整點 的位置，
         const initStartTime = moment(date).hours(8);
         const endOfDay = moment(date).endOf("day");
-        const hourRange = 6;
+        const hourRange = 13;
         const rangeBetweenNowAndEndOfDay = endOfDay.diff(
           initStartTime,
           "hours"
@@ -290,71 +292,79 @@
         };
       }
 
-      const testData = [
-        {
-          id: 0,
-          order_id: 3191484087511,
-          order_created_at: "2023-10-04 09:44:07",
-          start: setTime({ hour: 10, minute: 0 }),
-          end: setTime({ hour: 11, minute: 0 }),
-          order_display_status: 0,
-          cust_name: "Debby test",
-          cust_title: "小姐",
+      const testData = {
+        group: {
+          id: "unassigned",
+          content: "Unassigned",
         },
-        {
-          id: 1,
-          order_id: 3191487353494,
-          order_created_at: "2023-10-04 09:44:26",
-          start: setTime({ hour: 10, minute: 15 }),
-          end: setTime({ hour: 11, minute: 15 }),
-          order_display_status: 9,
-          cust_name: "Debby test",
-          cust_title: "小姐",
-        },
-        {
-          id: 2,
-          order_id: 3191507404885,
-          order_created_at: "2023-10-04 09:44:43",
-          start: setTime({ hour: 10, minute: 45 }),
-          end: setTime({ hour: 11, minute: 45 }),
-          order_display_status: 1,
-          cust_name: "Debby test",
-          cust_title: "小姐",
-        },
-        {
-          id: 3,
-          order_id: 3191497164243,
-          order_created_at: "2023-10-04 09:45:47",
-          start: setTime({ hour: 11, minute: 15 }),
-          end: setTime({ hour: 12, minute: 15 }),
-          order_display_status: 0,
-          cust_name: "Debby test",
-          cust_title: "小姐",
-        },
-        {
-          id: 4,
-          order_id: 3191498472338,
-          order_created_at: "2023-10-04 09:46:12",
-          start: setTime({ hour: 11, minute: 0 }),
-          end: setTime({ hour: 12, minute: 0 }),
-          order_display_status: 8,
-          cust_name: "Debby test",
-          cust_title: "小姐",
-        },
-        {
-          id: 5,
-          order_id: 3191589533034,
-          order_created_at: "2023-10-04 22:35:27",
-          start: setTime({ hour: 11, minute: 0 }),
-          end: setTime({ hour: 12, minute: 0 }),
+        items: [
+          {
+            id: 1,
+            order_id: 3191484087511,
+            order_created_at: "2023-10-04 09:44:07",
+            start: setTime({ hour: 10, minute: 0 }),
+            end: setTime({ hour: 11, minute: 0 }),
+            order_display_status: 0,
+            cust_name: "Debby test",
+            cust_title: "小姐",
+          },
+          {
+            id: 2,
+            order_id: 3191487353494,
+            order_created_at: "2023-10-04 09:44:26",
+            start: setTime({ hour: 10, minute: 15 }),
+            end: setTime({ hour: 11, minute: 15 }),
+            order_display_status: 9,
+            cust_name: "Debby test",
+            cust_title: "小姐",
+          },
+          {
+            id: 3,
+            order_id: 3191507404885,
+            order_created_at: "2023-10-04 09:44:43",
+            start: setTime({ hour: 10, minute: 45 }),
+            end: setTime({ hour: 11, minute: 45 }),
+            order_display_status: 1,
+            cust_name: "Debby test",
+            cust_title: "小姐",
+          },
+          {
+            id: 4,
+            order_id: 3191497164243,
+            order_created_at: "2023-10-04 09:45:47",
+            start: setTime({ hour: 11, minute: 15 }),
+            end: setTime({ hour: 12, minute: 15 }),
+            order_display_status: 0,
+            cust_name: "Debby test",
+            cust_title: "小姐",
+          },
+          {
+            id: 5,
+            order_id: 3191498472338,
+            order_created_at: "2023-10-04 09:46:12",
+            start: setTime({ hour: 11, minute: 0 }),
+            end: setTime({ hour: 12, minute: 0 }),
+            order_display_status: 8,
+            cust_name: "Debby test",
+            cust_title: "小姐",
+          },
+          {
+            id: 6,
+            order_id: 3191589533034,
+            order_created_at: "2023-10-04 22:35:27",
+            start: setTime({ hour: 11, minute: 0 }),
+            end: setTime({ hour: 12, minute: 0 }),
 
-          order_display_status: 0,
-          cust_name: "Debby test",
-          cust_title: "小姐",
-        },
-      ];
+            order_display_status: 0,
+            cust_name: "Debby test",
+            cust_title: "小姐",
+          },
+        ],
+      };
 
-      const { groupDataSet, itemDataSet } = generateGroupWithOverlapItem();
+      const { groupDataSet, itemDataSet } = generateGroupWithOverlapItem(0);
+
+      groupDataSet.add(testData.group);
 
       var GroupTemplate = (group) => {
         const className = `group-container`;
@@ -370,14 +380,14 @@
           super(props);
         }
         render() {
-          const { content, start, end, data } = this.props.item;
+          const { start, end, data } = this.props.item;
           const className = `${
             DISPLAY_STATUS_MAP[data.order_display_status]
           } item-container`;
           return (
             <div className={className}>
               <div className="item-container__content">
-                <div>{content}</div>
+                <div>{data.id} </div>
                 <div>{moment(start).format("HH:mm")}</div>
               </div>
             </div>
@@ -389,6 +399,7 @@
       const timelineStartAndEnd = getTodayTimelineStartAndEndByDeviceWidth(
         moment()
       );
+
       // specify options
       const options = {
         showCurrentTime: false, // 隱藏 timeline 上的 current time，改為自己實作
@@ -402,8 +413,10 @@
         verticalScroll: true,
         horizontalScroll: true,
         // 由於 timeline 會自動計算 cell 的寬度，為了滿足需求，所以這邊要自行使用 start/end 來計算 cell 的寬度
-        start: timelineStartAndEnd.start,
-        end: timelineStartAndEnd.end,
+        // start: timelineStartAndEnd.start,
+        start: moment().set({ hour: 13, minute: 0, second: 0 }),
+        end: moment().set({ hour: 23, minute: 0, second: 0 }),
+        // end: timelineStartAndEnd.end,
         // 設下 min/max 邊界防止 timeline 無限滾動，以及設定 zoomable 為 false 防止使用者縮放
         min: moment(selectedDate).startOf("day").valueOf(),
         max: moment(selectedDate).endOf("day").valueOf(),
@@ -439,7 +452,25 @@
         },
         onInitialDrawComplete: () => {
           console.log("%conInitialDrawComplete", "color: #bada55");
-          window.timeline.setItems(itemDataSet);
+          // window.timeline.setItems(itemDataSet);
+          const testItems = testData.items.sort(sortSlots).map((item) => ({
+            ...item,
+            group: "unassigned",
+            data: item,
+          }));
+          console.log(
+            "testItems init ids order:>> ",
+            testItems.map((o) => o.id)
+          );
+          itemDataSet.update(testItems);
+          // testData.items.sort(sortSlots).forEach(item =>{
+          //   console.log('item.id :>> ', item.id);
+          //   itemDataSet.add({
+          //     ...item,
+          //     group: 'unassigned',
+          //     data: item
+          //   })
+          // })
           console.timeEnd("timeline");
         },
         template: function (item, element) {
@@ -481,14 +512,17 @@
         }
 
         onGroupAmountChange(e) {
+          const amount = Number(e.target.value);
           this.setState({
-            groupAmount: Number(e.target.value),
+            groupAmount: amount < 1 ? 1 : amount,
           });
         }
 
         onItemAmountChange(e) {
+          const amount = Number(e.target.value);
+
           this.setState({
-            itemAmount: Number(e.target.value),
+            itemAmount: amount > 96 ? 96 : amount < 1 ? 1 : amount,
           });
         }
 
@@ -525,6 +559,8 @@
                   <span>Group with </span>
                   <input
                     type="number"
+                    min="1"
+                    max="96"
                     value={this.state.itemAmount}
                     onChange={this.onItemAmountChange.bind(this)}
                   />
@@ -542,7 +578,7 @@
         var container = document.getElementById("visualization");
         window.timeline = new vis.Timeline(
           container,
-          [],
+          itemDataSet,
           groupDataSet,
           options
         );

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -1,25 +1,24 @@
-import util from '../../util';
-import * as stack from '../Stack';
+import util from "../../util";
+import * as stack from "../Stack";
 
-const UNGROUPED = '__ungrouped__';   // reserved group id for ungrouped items
-const BACKGROUND = '__background__'; // reserved group id for background items without group
+const UNGROUPED = "__ungrouped__"; // reserved group id for ungrouped items
+const BACKGROUND = "__background__"; // reserved group id for background items without group
 
 export const ReservedGroupIds = {
   UNGROUPED,
-  BACKGROUND
-}
-
+  BACKGROUND,
+};
 
 /**
  * @constructor Group
  */
 class Group {
   /**
- * @param {number | string} groupId
- * @param {Object} data
- * @param {ItemSet} itemSet
- * @constructor Group
- */
+   * @param {number | string} groupId
+   * @param {Object} data
+   * @param {ItemSet} itemSet
+   * @constructor Group
+   */
   constructor(groupId, data, itemSet) {
     this.groupId = groupId;
     this.subgroups = {};
@@ -53,11 +52,10 @@ class Group {
       if (typeof data.subgroupStack === "boolean") {
         this.doInnerStack = data.subgroupStack;
         this.subgroupStackAll = data.subgroupStack;
-      }
-      else {
+      } else {
         // We might be doing stacking on specific sub groups, but only
         // if at least one is set to do stacking
-        for(const key in data.subgroupStack) {
+        for (const key in data.subgroupStack) {
           this.subgroupStack[key] = data.subgroupStack[key];
           this.doInnerStack = this.doInnerStack || data.subgroupStack[key];
         }
@@ -76,17 +74,17 @@ class Group {
     this.props = {
       label: {
         width: 0,
-        height: 0
-      }
+        height: 0,
+      },
     };
     this.className = null;
 
-    this.items = {};        // items filtered by groupId of this group
+    this.items = {}; // items filtered by groupId of this group
     this.visibleItems = []; // items currently visible in window
     this.itemsInRange = []; // items currently in range
     this.orderedItems = {
       byStart: [],
-      byEnd: []
+      byEnd: [],
     };
     this.checkRangedItems = false; // needed to refresh the ranged items if the window is programatically changed with NO overlap.
 
@@ -108,37 +106,37 @@ class Group {
    * @private
    */
   _create() {
-    const label = document.createElement('div');
+    const label = document.createElement("div");
     if (this.itemSet.options.groupEditable.order) {
-      label.className = 'vis-label draggable';
+      label.className = "vis-label draggable";
     } else {
-      label.className = 'vis-label';
+      label.className = "vis-label";
     }
     this.dom.label = label;
 
-    const inner = document.createElement('div');
-    inner.className = 'vis-inner';
+    const inner = document.createElement("div");
+    inner.className = "vis-inner";
     label.appendChild(inner);
     this.dom.inner = inner;
 
-    const foreground = document.createElement('div');
-    foreground.className = 'vis-group';
-    foreground['vis-group'] = this;
+    const foreground = document.createElement("div");
+    foreground.className = "vis-group";
+    foreground["vis-group"] = this;
     this.dom.foreground = foreground;
 
-    this.dom.background = document.createElement('div');
-    this.dom.background.className = 'vis-group';
+    this.dom.background = document.createElement("div");
+    this.dom.background.className = "vis-group";
 
-    this.dom.axis = document.createElement('div');
-    this.dom.axis.className = 'vis-group';
+    this.dom.axis = document.createElement("div");
+    this.dom.axis.className = "vis-group";
 
     // create a hidden marker to detect when the Timelines container is attached
     // to the DOM, or the style of a parent of the Timeline is changed from
     // display:none is changed to visible.
-    this.dom.marker = document.createElement('div');
-    this.dom.marker.style.visibility = 'hidden';
-    this.dom.marker.style.position = 'absolute';
-    this.dom.marker.innerHTML = '';
+    this.dom.marker = document.createElement("div");
+    this.dom.marker.style.visibility = "hidden";
+    this.dom.marker.style.position = "absolute";
+    this.dom.marker.innerHTML = "";
     this.dom.background.appendChild(this.dom.marker);
   }
 
@@ -180,16 +178,15 @@ class Group {
     } else if (content !== undefined && content !== null) {
       this.dom.inner.innerHTML = util.xss(content);
     } else {
-      this.dom.inner.innerHTML = util.xss(this.groupId || ''); // groupId can be null
+      this.dom.inner.innerHTML = util.xss(this.groupId || ""); // groupId can be null
     }
 
     // update title
-    this.dom.label.title = data && data.title || '';
+    this.dom.label.title = (data && data.title) || "";
     if (!this.dom.inner.firstChild) {
-      util.addClassName(this.dom.inner, 'vis-hidden');
-    }
-    else {
-      util.removeClassName(this.dom.inner, 'vis-hidden');
+      util.addClassName(this.dom.inner, "vis-hidden");
+    } else {
+      util.removeClassName(this.dom.inner, "vis-hidden");
     }
 
     if (data && data.nestedGroups) {
@@ -205,35 +202,35 @@ class Group {
         }
       }
 
-      util.addClassName(this.dom.label, 'vis-nesting-group');
+      util.addClassName(this.dom.label, "vis-nesting-group");
       if (this.showNested) {
-        util.removeClassName(this.dom.label, 'collapsed');
-        util.addClassName(this.dom.label, 'expanded');
+        util.removeClassName(this.dom.label, "collapsed");
+        util.addClassName(this.dom.label, "expanded");
       } else {
-        util.removeClassName(this.dom.label, 'expanded');
-        util.addClassName(this.dom.label, 'collapsed');
+        util.removeClassName(this.dom.label, "expanded");
+        util.addClassName(this.dom.label, "collapsed");
       }
     } else if (this.nestedGroups) {
       this.nestedGroups = null;
-      util.removeClassName(this.dom.label, 'collapsed');
-      util.removeClassName(this.dom.label, 'expanded');
-      util.removeClassName(this.dom.label, 'vis-nesting-group');
+      util.removeClassName(this.dom.label, "collapsed");
+      util.removeClassName(this.dom.label, "expanded");
+      util.removeClassName(this.dom.label, "vis-nesting-group");
     }
 
-    if (data && (data.treeLevel|| data.nestedInGroup)) {
-      util.addClassName(this.dom.label, 'vis-nested-group');
+    if (data && (data.treeLevel || data.nestedInGroup)) {
+      util.addClassName(this.dom.label, "vis-nested-group");
       if (data.treeLevel) {
-        util.addClassName(this.dom.label, 'vis-group-level-' + data.treeLevel);
+        util.addClassName(this.dom.label, "vis-group-level-" + data.treeLevel);
       } else {
         // Nesting level is unknown, but we're sure it's at least 1
-        util.addClassName(this.dom.label, 'vis-group-level-unknown-but-gte1');
+        util.addClassName(this.dom.label, "vis-group-level-unknown-but-gte1");
       }
     } else {
-      util.addClassName(this.dom.label, 'vis-group-level-0');
+      util.addClassName(this.dom.label, "vis-group-level-0");
     }
-    
+
     // update className
-    const className = data && data.className || null;
+    const className = (data && data.className) || null;
     if (className != this.className) {
       if (this.className) {
         util.removeClassName(this.dom.label, this.className);
@@ -269,7 +266,7 @@ class Group {
 
   /**
    * check if group has had an initial height hange
-   * @returns {boolean} 
+   * @returns {boolean}
    */
   _didMarkerHeightChange() {
     const markerHeight = this.dom.marker.clientHeight;
@@ -285,13 +282,13 @@ class Group {
           redrawQueue[key] = item.redraw(returnQueue);
           redrawQueueLength = redrawQueue[key].length;
         }
-      })
+      });
 
       const needRedraw = redrawQueueLength > 0;
       if (needRedraw) {
         // redraw all regular items
         for (let i = 0; i < redrawQueueLength; i++) {
-          util.forEach(redrawQueue, fns => {
+          util.forEach(redrawQueue, (fns) => {
             fns[i]();
           });
         }
@@ -315,7 +312,7 @@ class Group {
 
   /**
    * checks if should bail redraw of items
-   * @returns {boolean} should bail 
+   * @returns {boolean} should bail
    */
   _shouldBailItemsRedraw() {
     const me = this;
@@ -324,17 +321,25 @@ class Group {
       relativeBailingTime: this.itemSet.itemsSettingTime,
       bailTimeMs: timeoutOptions && timeoutOptions.timeoutMs,
       userBailFunction: timeoutOptions && timeoutOptions.callback,
-      shouldBailStackItems: this.shouldBailStackItems
+      shouldBailStackItems: this.shouldBailStackItems,
     };
     let bail = null;
     if (!this.itemSet.initialDrawDone) {
-      if (bailOptions.shouldBailStackItems) { return true; }
-      if (Math.abs(Date.now() - new Date(bailOptions.relativeBailingTime)) > bailOptions.bailTimeMs) {
-        if (bailOptions.userBailFunction && this.itemSet.userContinueNotBail == null) {
-          bailOptions.userBailFunction(didUserContinue => {
+      if (bailOptions.shouldBailStackItems) {
+        return true;
+      }
+      if (
+        Math.abs(Date.now() - new Date(bailOptions.relativeBailingTime)) >
+        bailOptions.bailTimeMs
+      ) {
+        if (
+          bailOptions.userBailFunction &&
+          this.itemSet.userContinueNotBail == null
+        ) {
+          bailOptions.userBailFunction((didUserContinue) => {
             me.itemSet.userContinueNotBail = didUserContinue;
             bail = !didUserContinue;
-          })
+          });
         } else if (me.itemSet.userContinueNotBail == false) {
           bail = true;
         } else {
@@ -355,67 +360,104 @@ class Group {
    * @private
    */
   _redrawItems(forceRestack, lastIsVisible, margin, range) {
-    const restack = forceRestack || this.stackDirty || this.isVisible && !lastIsVisible;
+    const restack =
+      forceRestack || this.stackDirty || (this.isVisible && !lastIsVisible);
 
     // if restacking, reposition visible items vertically
     if (restack) {
       const orderedItems = {
-        byEnd: this.orderedItems.byEnd.filter(item => !item.isCluster),
-        byStart: this.orderedItems.byStart.filter(item => !item.isCluster)
-      }
+        byEnd: this.orderedItems.byEnd.filter((item) => !item.isCluster),
+        byStart: this.orderedItems.byStart.filter((item) => !item.isCluster),
+      };
 
       const orderedClusters = {
-        byEnd: [...new Set(this.orderedItems.byEnd.map(item => item.cluster).filter(item => !!item))],
-        byStart: [...new Set(this.orderedItems.byStart.map(item => item.cluster).filter(item => !!item))],
-      }
+        byEnd: [
+          ...new Set(
+            this.orderedItems.byEnd
+              .map((item) => item.cluster)
+              .filter((item) => !!item)
+          ),
+        ],
+        byStart: [
+          ...new Set(
+            this.orderedItems.byStart
+              .map((item) => item.cluster)
+              .filter((item) => !!item)
+          ),
+        ],
+      };
 
-     /**
-     * Get all visible items in range
-     * @return {array} items
-     */
+      /**
+       * Get all visible items in range
+       * @return {array} items
+       */
       const getVisibleItems = () => {
-        const visibleItems = this._updateItemsInRange(orderedItems, this.visibleItems.filter(item => !item.isCluster), range);
-        const visibleClusters = this._updateClustersInRange(orderedClusters, this.visibleItems.filter(item => item.isCluster), range);
+        const visibleItems = this._updateItemsInRange(
+          orderedItems,
+          this.visibleItems.filter((item) => !item.isCluster),
+          range
+        );
+        const visibleClusters = this._updateClustersInRange(
+          orderedClusters,
+          this.visibleItems.filter((item) => item.isCluster),
+          range
+        );
         return [...visibleItems, ...visibleClusters];
-      }
+      };
 
       /**
        * Get visible items grouped by subgroup
        * @param {function} orderFn An optional function to order items inside the subgroups
        * @return {Object}
        */
-      const getVisibleItemsGroupedBySubgroup = orderFn => {
+      const getVisibleItemsGroupedBySubgroup = (orderFn) => {
         let visibleSubgroupsItems = {};
         for (const subgroup in this.subgroups) {
-          const items = this.visibleItems.filter(item => item.data.subgroup === subgroup);
-          visibleSubgroupsItems[subgroup] = orderFn ? items.sort((a, b) => orderFn(a.data, b.data)) : items;
+          const items = this.visibleItems.filter(
+            (item) => item.data.subgroup === subgroup
+          );
+          visibleSubgroupsItems[subgroup] = orderFn
+            ? items.sort((a, b) => orderFn(a.data, b.data))
+            : items;
         }
         return visibleSubgroupsItems;
       };
 
-      if (typeof this.itemSet.options.order === 'function') {
+      if (typeof this.itemSet.options.order === "function") {
         // a custom order function
         //show all items
         const me = this;
         if (this.doInnerStack && this.itemSet.options.stackSubgroups) {
           // Order the items within each subgroup
-          const visibleSubgroupsItems = getVisibleItemsGroupedBySubgroup(this.itemSet.options.order);
-          stack.stackSubgroupsWithInnerStack(visibleSubgroupsItems, margin, this.subgroups);
+          const visibleSubgroupsItems = getVisibleItemsGroupedBySubgroup(
+            this.itemSet.options.order
+          );
+          stack.stackSubgroupsWithInnerStack(
+            visibleSubgroupsItems,
+            margin,
+            this.subgroups
+          );
           this.visibleItems = getVisibleItems();
           this._updateSubGroupHeights(margin);
-        }
-        else {
+        } else {
           this.visibleItems = getVisibleItems();
           this._updateSubGroupHeights(margin);
           // order all items and force a restacking
-           // order all items outside clusters and force a restacking
+          // order all items outside clusters and force a restacking
           const customOrderedItems = this.visibleItems
-                                  .slice()
-                                  .filter(item => item.isCluster || (!item.isCluster && !item.cluster))
-                                  .sort((a, b) => {
-                                      return me.itemSet.options.order(a.data, b.data);
-                                  });
-          this.shouldBailStackItems = stack.stack(customOrderedItems, margin, true, this._shouldBailItemsRedraw.bind(this));
+            .slice()
+            .filter(
+              (item) => item.isCluster || (!item.isCluster && !item.cluster)
+            )
+            .sort((a, b) => {
+              return me.itemSet.options.order(a.data, b.data);
+            });
+          this.shouldBailStackItems = stack.stack(
+            customOrderedItems,
+            margin,
+            true,
+            this._shouldBailItemsRedraw.bind(this)
+          );
         }
       } else {
         // no custom order function, lazy stacking
@@ -425,21 +467,37 @@ class Group {
         if (this.itemSet.options.stack) {
           if (this.doInnerStack && this.itemSet.options.stackSubgroups) {
             const visibleSubgroupsItems = getVisibleItemsGroupedBySubgroup();
-            stack.stackSubgroupsWithInnerStack(visibleSubgroupsItems, margin, this.subgroups);
-          }
-          else {
+            stack.stackSubgroupsWithInnerStack(
+              visibleSubgroupsItems,
+              margin,
+              this.subgroups
+            );
+          } else {
             // TODO: ugly way to access options...
-            this.shouldBailStackItems = stack.stack(this.visibleItems, margin, true, this._shouldBailItemsRedraw.bind(this));
+            this.shouldBailStackItems = stack.stack(
+              this.visibleItems,
+              margin,
+              true,
+              this._shouldBailItemsRedraw.bind(this)
+            );
           }
         } else {
           // no stacking
-          stack.nostack(this.visibleItems, margin, this.subgroups, this.itemSet.options.stackSubgroups);
+          stack.nostack(
+            this.visibleItems,
+            margin,
+            this.subgroups,
+            this.itemSet.options.stackSubgroups
+          );
         }
       }
 
       for (let i = 0; i < this.visibleItems.length; i++) {
         this.visibleItems[i].repositionX();
-        if (this.subgroupVisibility[this.visibleItems[i].data.subgroup] !== undefined) {
+        if (
+          this.subgroupVisibility[this.visibleItems[i].data.subgroup] !==
+          undefined
+        ) {
           if (!this.subgroupVisibility[this.visibleItems[i].data.subgroup]) {
             this.visibleItems[i].hide();
           }
@@ -447,7 +505,7 @@ class Group {
       }
 
       if (this.itemSet.options.cluster) {
-        util.forEach(this.items, item => {
+        util.forEach(this.items, (item) => {
           if (item.cluster && item.displayed) {
             item.hide();
           }
@@ -455,7 +513,7 @@ class Group {
       }
 
       if (this.shouldBailStackItems) {
-        this.itemSet.body.emitter.emit('destroyTimeline')
+        this.itemSet.body.emitter.emit("destroyTimeline");
       }
       this.stackDirty = false;
     }
@@ -468,12 +526,14 @@ class Group {
    * @return {boolean} did resize
    */
   _didResize(resized, height) {
-    resized = util.updateProperty(this, 'height', height) || resized;
+    resized = util.updateProperty(this, "height", height) || resized;
     // recalculate size of label
     const labelWidth = this.dom.inner.clientWidth;
     const labelHeight = this.dom.inner.clientHeight;
-    resized = util.updateProperty(this.props.label, 'width', labelWidth) || resized;
-    resized = util.updateProperty(this.props.label, 'height', labelHeight) || resized;
+    resized =
+      util.updateProperty(this.props.label, "width", labelWidth) || resized;
+    resized =
+      util.updateProperty(this.props.label, "height", labelHeight) || resized;
     return resized;
   }
 
@@ -518,7 +578,7 @@ class Group {
       () => {
         forceRestack = this._didMarkerHeightChange.call(this) || forceRestack;
       },
-      
+
       // recalculate the height of the subgroups
       this._updateSubGroupHeights.bind(this, margin),
 
@@ -528,9 +588,14 @@ class Group {
       () => {
         this.isVisible = this._isGroupVisible.bind(this)(range, margin);
       },
-      
+
       () => {
-        this._redrawItems.bind(this)(forceRestack, lastIsVisible, margin, range)
+        this._redrawItems.bind(this)(
+          forceRestack,
+          lastIsVisible,
+          margin,
+          range
+        );
       },
 
       // update subgroups
@@ -544,30 +609,30 @@ class Group {
       this._calculateGroupSizeAndPosition.bind(this),
 
       () => {
-        resized = this._didResize.bind(this)(resized, height)
+        resized = this._didResize.bind(this)(resized, height);
       },
 
       () => {
-        this._applyGroupHeight.bind(this)(height)
+        this._applyGroupHeight.bind(this)(height);
       },
 
       () => {
-        this._updateItemsVerticalPosition.bind(this)(margin)
+        this._updateItemsVerticalPosition.bind(this)(margin);
       },
 
       (() => {
         if (!this.isVisible && this.height) {
           resized = false;
         }
-        return resized
-      }).bind(this)
+        return resized;
+      }).bind(this),
     ];
 
     if (returnQueue) {
       return queue;
     } else {
       let result;
-      queue.forEach(fn => {
+      queue.forEach((fn) => {
         result = fn();
       });
       return result;
@@ -586,10 +651,16 @@ class Group {
 
       this._resetSubgroups();
 
-      util.forEach(this.visibleItems, item => {
+      util.forEach(this.visibleItems, (item) => {
         if (item.data.subgroup !== undefined) {
-          me.subgroups[item.data.subgroup].height = Math.max(me.subgroups[item.data.subgroup].height, item.height + margin.item.vertical);
-          me.subgroups[item.data.subgroup].visible = typeof this.subgroupVisibility[item.data.subgroup] === 'undefined' ? true : Boolean(this.subgroupVisibility[item.data.subgroup]);
+          me.subgroups[item.data.subgroup].height = Math.max(
+            me.subgroups[item.data.subgroup].height,
+            item.height + margin.item.vertical
+          );
+          me.subgroups[item.data.subgroup].visible =
+            typeof this.subgroupVisibility[item.data.subgroup] === "undefined"
+              ? true
+              : Boolean(this.subgroupVisibility[item.data.subgroup]);
         }
       });
     }
@@ -604,8 +675,13 @@ class Group {
    * @private
    */
   _isGroupVisible(range, margin) {
-    return (this.top <= range.body.domProps.centerContainer.height - range.body.domProps.scrollTop + margin.axis)
-    && (this.top + this.height + margin.axis >= - range.body.domProps.scrollTop);
+    return (
+      this.top <=
+        range.body.domProps.centerContainer.height -
+          range.body.domProps.scrollTop +
+          margin.axis &&
+      this.top + this.height + margin.axis >= -range.body.domProps.scrollTop
+    );
   }
 
   /**
@@ -620,7 +696,7 @@ class Group {
 
     let items;
 
-    if (this.heightMode === 'fixed') {
+    if (this.heightMode === "fixed") {
       items = util.toArray(this.items);
     } else {
       // default or 'auto'
@@ -630,15 +706,15 @@ class Group {
     if (items.length > 0) {
       let min = items[0].top;
       let max = items[0].top + items[0].height;
-      util.forEach(items, item => {
+      util.forEach(items, (item) => {
         min = Math.min(min, item.top);
-        max = Math.max(max, (item.top + item.height));
+        max = Math.max(max, item.top + item.height);
       });
       if (min > margin.axis) {
         // there is an empty gap between the lowest item and the axis
         const offset = min - margin.axis;
         max -= offset;
-        util.forEach(items, item => {
+        util.forEach(items, (item) => {
           item.top -= offset;
         });
       }
@@ -646,8 +722,7 @@ class Group {
       if (this.heightMode !== "fitItems") {
         height = Math.max(height, this.props.label.height);
       }
-    }
-    else {
+    } else {
       height = 0 || this.props.label.height;
     }
     return height;
@@ -724,7 +799,7 @@ class Group {
    * @param {object} item
    * @param {string} subgroupId
    */
-  _addToSubgroup(item, subgroupId=item.data.subgroup) {
+  _addToSubgroup(item, subgroupId = item.data.subgroup) {
     if (subgroupId != undefined && this.subgroups[subgroupId] === undefined) {
       this.subgroups[subgroupId] = {
         height: 0,
@@ -734,13 +809,14 @@ class Group {
         visible: false,
         index: this.subgroupIndex,
         items: [],
-        stack: this.subgroupStackAll || this.subgroupStack[subgroupId] || false
+        stack: this.subgroupStackAll || this.subgroupStack[subgroupId] || false,
       };
       this.subgroupIndex++;
     }
 
-
-    if (new Date(item.data.start) < new Date(this.subgroups[subgroupId].start)) {
+    if (
+      new Date(item.data.start) < new Date(this.subgroups[subgroupId].start)
+    ) {
       this.subgroups[subgroupId].start = item.data.start;
     }
 
@@ -759,11 +835,13 @@ class Group {
     const me = this;
     if (me.subgroups) {
       for (const subgroup in me.subgroups) {
-        const initialEnd = me.subgroups[subgroup].items[0].data.end || me.subgroups[subgroup].items[0].data.start;
+        const initialEnd =
+          me.subgroups[subgroup].items[0].data.end ||
+          me.subgroups[subgroup].items[0].data.start;
         let newStart = me.subgroups[subgroup].items[0].data.start;
         let newEnd = initialEnd - 1;
 
-        me.subgroups[subgroup].items.forEach(item => {
+        me.subgroups[subgroup].items.forEach((item) => {
           if (new Date(item.data.start) < new Date(newStart)) {
             newStart = item.data.start;
           }
@@ -772,11 +850,10 @@ class Group {
           if (new Date(itemEnd) > new Date(newEnd)) {
             newEnd = itemEnd;
           }
-        })
+        });
 
         me.subgroups[subgroup].start = newStart;
-        me.subgroups[subgroup].end = new Date(newEnd - 1) // -1 to compensate for colliding end to start subgroups;
-
+        me.subgroups[subgroup].end = new Date(newEnd - 1); // -1 to compensate for colliding end to start subgroups;
       }
     }
   }
@@ -787,13 +864,16 @@ class Group {
   orderSubgroups() {
     if (this.subgroupOrderer !== undefined) {
       const sortArray = [];
-      if (typeof this.subgroupOrderer == 'string') {
+      if (typeof this.subgroupOrderer == "string") {
         for (const subgroup in this.subgroups) {
-          sortArray.push({subgroup, sortField: this.subgroups[subgroup].items[0].data[this.subgroupOrderer]})
+          sortArray.push({
+            subgroup,
+            sortField:
+              this.subgroups[subgroup].items[0].data[this.subgroupOrderer],
+          });
         }
-        sortArray.sort((a, b) => a.sortField - b.sortField)
-      }
-      else if (typeof this.subgroupOrderer == 'function') {
+        sortArray.sort((a, b) => a.sortField - b.sortField);
+      } else if (typeof this.subgroupOrderer == "function") {
         for (const subgroup in this.subgroups) {
           sortArray.push(this.subgroups[subgroup].items[0].data);
         }
@@ -813,6 +893,7 @@ class Group {
    */
   _resetSubgroups() {
     for (const subgroup in this.subgroups) {
+      // eslint-disable-next-line no-prototype-builtins
       if (this.subgroups.hasOwnProperty(subgroup)) {
         this.subgroups[subgroup].visible = false;
         this.subgroups[subgroup].height = 0;
@@ -833,7 +914,7 @@ class Group {
     const index = this.visibleItems.indexOf(item);
     if (index != -1) this.visibleItems.splice(index, 1);
 
-    if(item.data.subgroup !== undefined){
+    if (item.data.subgroup !== undefined) {
       this._removeFromSubgroup(item);
       this.orderSubgroups();
     }
@@ -844,15 +925,15 @@ class Group {
    * @param {object} item
    * @param {string} subgroupId
    */
-  _removeFromSubgroup(item, subgroupId=item.data.subgroup) {
+  _removeFromSubgroup(item, subgroupId = item.data.subgroup) {
     if (subgroupId != undefined) {
       const subgroup = this.subgroups[subgroupId];
-      if (subgroup){
+      if (subgroup) {
         const itemIndex = subgroup.items.indexOf(item);
         //  Check the item is actually in this subgroup. How should items not in the group be handled?
         if (itemIndex >= 0) {
-          subgroup.items.splice(itemIndex,1);
-          if (!subgroup.items.length){
+          subgroup.items.splice(itemIndex, 1);
+          if (!subgroup.items.length) {
             delete this.subgroups[subgroupId];
           } else {
             this._updateSubgroupsSizes();
@@ -886,7 +967,7 @@ class Group {
     }
     this.orderedItems = {
       byStart: startArray,
-      byEnd: endArray
+      byEnd: endArray,
     };
 
     stack.orderByStart(this.orderedItems.byStart);
@@ -901,85 +982,89 @@ class Group {
    * @return {Item[]} visibleItems                            The new visible items.
    * @private
    */
-  _updateItemsInRange(orderedItems, oldVisibleItems, range) {
-    const visibleItems = [];
-    const visibleItemsLookup = {}; // we keep this to quickly look up if an item already exists in the list without using indexOf on visibleItems
+  _updateItemsInRange(orderedItems) {
+    const visibleItems = orderedItems.byStart;
+    // FIXME: 由於這邊會自動銷毀當前可視時間軸範圍外的 Item，會導致排序與我們預期的不一致。
+    // 所以這邊先暫時不做任何事情，讓所有 Item 都呈現在 DOM tree 中，等到我們有需要的時候再來處理。
 
-    if (!this.isVisible && this.groupId != ReservedGroupIds.BACKGROUND) {
-      for (let i = 0; i < oldVisibleItems.length; i++) {
-        var item = oldVisibleItems[i];
-        if (item.displayed) item.hide();
-      }
-      return visibleItems;
-    } 
+    // let visibleItems = [];
+    // const visibleItemsLookup = {}; // we keep this to quickly look up if an item already exists in the list without using indexOf on visibleItems
 
-    const interval = (range.end - range.start) / 4;
-    const lowerBound = range.start - interval;
-    const upperBound = range.end + interval;
+    // if (!this.isVisible && this.groupId != ReservedGroupIds.BACKGROUND) {
+    //   for (let i = 0; i < oldVisibleItems.length; i++) {
+    //     var item = oldVisibleItems[i];
+    //     if (item.displayed) item.hide();
+    //   }
+    //   return visibleItems;
+    // }
 
-    // this function is used to do the binary search for items having start date only.
-    const startSearchFunction = value => {
-      if      (value < lowerBound)  {return -1;}
-      else if (value <= upperBound) {return  0;}
-      else                          {return  1;}
-    };
+    // const interval = (range.end - range.start) / 4;
+    // const lowerBound = range.start - interval;
+    // const upperBound = range.end + interval;
 
-    // this function is used to do the binary search for items having start and end dates (range).
-    const endSearchFunction = data => {
-      const {start, end} = data;
-      if      (end < lowerBound)    {return -1;}
-      else if (start <= upperBound) {return  0;}
-      else                          {return  1;}
-    }
+    // // this function is used to do the binary search for items having start date only.
+    // const startSearchFunction = value => {
+    //   if      (value < lowerBound)  {return -1;}
+    //   else if (value <= upperBound) {return  0;}
+    //   else                          {return  1;}
+    // };
 
-    // first check if the items that were in view previously are still in view.
-    // IMPORTANT: this handles the case for the items with startdate before the window and enddate after the window!
-    // also cleans up invisible items.
-    if (oldVisibleItems.length > 0) {
-      for (let i = 0; i < oldVisibleItems.length; i++) {
-        this._checkIfVisibleWithReference(oldVisibleItems[i], visibleItems, visibleItemsLookup, range);
-      }
-    }
+    // // this function is used to do the binary search for items having start and end dates (range).
+    // const endSearchFunction = data => {
+    //   const {start, end} = data;
+    //   if      (end < lowerBound)    {return -1;}
+    //   else if (start <= upperBound) {return  0;}
+    //   else                          {return  1;}
+    // }
 
-    // we do a binary search for the items that have only start values.
-    const initialPosByStart = util.binarySearchCustom(orderedItems.byStart, startSearchFunction, 'data','start');
+    // // first check if the items that were in view previously are still in view.
+    // // IMPORTANT: this handles the case for the items with startdate before the window and enddate after the window!
+    // // also cleans up invisible items.
+    // if (oldVisibleItems.length > 0) {
+    //   for (let i = 0; i < oldVisibleItems.length; i++) {
+    //     this._checkIfVisibleWithReference(oldVisibleItems[i], visibleItems, visibleItemsLookup, range);
+    //   }
+    // }
 
-    // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the start values.
-    this._traceVisible(initialPosByStart, orderedItems.byStart, visibleItems, visibleItemsLookup, item => item.data.start < lowerBound || item.data.start > upperBound);
+    // // we do a binary search for the items that have only start values.
+    // const initialPosByStart = util.binarySearchCustom(orderedItems.byStart, startSearchFunction, 'data','start');
 
-    // if the window has changed programmatically without overlapping the old window, the ranged items with start < lowerBound and end > upperbound are not shown.
-    // We therefore have to brute force check all items in the byEnd list
-    if (this.checkRangedItems == true) {
-      this.checkRangedItems = false;
-      for (let i = 0; i < orderedItems.byEnd.length; i++) {
-        this._checkIfVisibleWithReference(orderedItems.byEnd[i], visibleItems, visibleItemsLookup, range);
-      }
-    }
-    else {
-      // we do a binary search for the items that have defined end times.
-      const initialPosByEnd = util.binarySearchCustom(orderedItems.byEnd, endSearchFunction, 'data');
+    // // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the start values.
+    // this._traceVisible(initialPosByStart, orderedItems.byStart, visibleItems, visibleItemsLookup, item => item.data.start < lowerBound || item.data.start > upperBound);
 
-      // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the end values.
-      this._traceVisible(initialPosByEnd, orderedItems.byEnd, visibleItems, visibleItemsLookup, item => item.data.end < lowerBound || item.data.start > upperBound);
-    }
+    // // if the window has changed programmatically without overlapping the old window, the ranged items with start < lowerBound and end > upperbound are not shown.
+    // // We therefore have to brute force check all items in the byEnd list
+    // if (this.checkRangedItems == true) {
+    //   this.checkRangedItems = false;
+    //   for (let i = 0; i < orderedItems.byEnd.length; i++) {
+    //     this._checkIfVisibleWithReference(orderedItems.byEnd[i], visibleItems, visibleItemsLookup, range);
+    //   }
+    // }
+    // else {
+    //   // we do a binary search for the items that have defined end times.
+    //   const initialPosByEnd = util.binarySearchCustom(orderedItems.byEnd, endSearchFunction, 'data');
+
+    //   // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the end values.
+    //   this._traceVisible(initialPosByEnd, orderedItems.byEnd, visibleItems, visibleItemsLookup, item => item.data.end < lowerBound || item.data.start > upperBound);
+    // }
 
     const redrawQueue = {};
     let redrawQueueLength = 0;
 
     for (let i = 0; i < visibleItems.length; i++) {
       const item = visibleItems[i];
+
       if (!item.displayed) {
         const returnQueue = true;
         redrawQueue[i] = item.redraw(returnQueue);
         redrawQueueLength = redrawQueue[i].length;
       }
     }
-
     const needRedraw = redrawQueueLength > 0;
     if (needRedraw) {
       // redraw all regular items
       for (let j = 0; j < redrawQueueLength; j++) {
-        util.forEach(redrawQueue, fns => {
+        util.forEach(redrawQueue, (fns) => {
           fns[j]();
         });
       }
@@ -1000,15 +1085,20 @@ class Group {
    * @param {object} visibleItemsLookup
    * @param {function} breakCondition
    */
-  _traceVisible(initialPos, items, visibleItems, visibleItemsLookup, breakCondition) {
+  _traceVisible(
+    initialPos,
+    items,
+    visibleItems,
+    visibleItemsLookup,
+    breakCondition
+  ) {
     if (initialPos != -1) {
       for (let i = initialPos; i >= 0; i--) {
         let item = items[i];
         if (breakCondition(item)) {
           break;
-        }
-        else {
-          if (!(item.isCluster  && !item.hasItems()) && !item.cluster) {
+        } else {
+          if (!(item.isCluster && !item.hasItems()) && !item.cluster) {
             if (visibleItemsLookup[item.id] === undefined) {
               visibleItemsLookup[item.id] = true;
               visibleItems.push(item);
@@ -1021,8 +1111,7 @@ class Group {
         let item = items[i];
         if (breakCondition(item)) {
           break;
-        }
-        else {
+        } else {
           if (!(item.isCluster && !item.hasItems()) && !item.cluster) {
             if (visibleItemsLookup[item.id] === undefined) {
               visibleItemsLookup[item.id] = true;
@@ -1046,15 +1135,14 @@ class Group {
    * @private
    */
   _checkIfVisible(item, visibleItems, range) {
-      if (item.isVisible(range)) {
-        if (!item.displayed) item.show();
-        // reposition item horizontally
-        item.repositionX();
-        visibleItems.push(item);
-      }
-      else {
-        if (item.displayed) item.hide();
-      }
+    if (item.isVisible(range)) {
+      if (!item.displayed) item.show();
+      // reposition item horizontally
+      item.repositionX();
+      visibleItems.push(item);
+    } else {
+      if (item.displayed) item.hide();
+    }
   }
 
   /**
@@ -1075,42 +1163,56 @@ class Group {
         visibleItemsLookup[item.id] = true;
         visibleItems.push(item);
       }
-    }
-    else {
+    } else {
       if (item.displayed) item.hide();
     }
   }
 
   /**
    * Update the visible items
-   * @param {array} orderedClusters 
-   * @param {array} oldVisibleClusters                         
-   * @param {{start: number, end: number}} range             
-   * @return {Item[]} visibleItems                            
+   * @param {array} orderedClusters
+   * @param {array} oldVisibleClusters
+   * @param {{start: number, end: number}} range
+   * @return {Item[]} visibleItems
    * @private
    */
   _updateClustersInRange(orderedClusters, oldVisibleClusters, range) {
     // Clusters can overlap each other so we cannot use binary search here
     const visibleClusters = [];
     const visibleClustersLookup = {}; // we keep this to quickly look up if an item already exists in the list without using indexOf on visibleItems
-  
+
     if (oldVisibleClusters.length > 0) {
       for (let i = 0; i < oldVisibleClusters.length; i++) {
-        this._checkIfVisibleWithReference(oldVisibleClusters[i], visibleClusters, visibleClustersLookup, range);
+        this._checkIfVisibleWithReference(
+          oldVisibleClusters[i],
+          visibleClusters,
+          visibleClustersLookup,
+          range
+        );
       }
     }
-  
+
     for (let i = 0; i < orderedClusters.byStart.length; i++) {
-      this._checkIfVisibleWithReference(orderedClusters.byStart[i], visibleClusters, visibleClustersLookup, range);
+      this._checkIfVisibleWithReference(
+        orderedClusters.byStart[i],
+        visibleClusters,
+        visibleClustersLookup,
+        range
+      );
     }
-  
+
     for (let i = 0; i < orderedClusters.byEnd.length; i++) {
-      this._checkIfVisibleWithReference(orderedClusters.byEnd[i], visibleClusters, visibleClustersLookup, range);
+      this._checkIfVisibleWithReference(
+        orderedClusters.byEnd[i],
+        visibleClusters,
+        visibleClustersLookup,
+        range
+      );
     }
-  
+
     const redrawQueue = {};
     let redrawQueueLength = 0;
-  
+
     for (let i = 0; i < visibleClusters.length; i++) {
       const item = visibleClusters[i];
       if (!item.displayed) {
@@ -1119,7 +1221,7 @@ class Group {
         redrawQueueLength = redrawQueue[i].length;
       }
     }
-  
+
     const needRedraw = redrawQueueLength > 0;
     if (needRedraw) {
       // redraw all regular items
@@ -1129,11 +1231,11 @@ class Group {
         });
       }
     }
-  
+
     for (let i = 0; i < visibleClusters.length; i++) {
       visibleClusters[i].repositionX();
     }
-    
+
     return visibleClusters;
   }
 

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -1134,15 +1134,16 @@ class Group {
    * @param {{start:number, end:number}} range
    * @private
    */
-  _checkIfVisible(item, visibleItems, range) {
-    if (item.isVisible(range)) {
-      if (!item.displayed) item.show();
-      // reposition item horizontally
-      item.repositionX();
-      visibleItems.push(item);
-    } else {
-      if (item.displayed) item.hide();
-    }
+  _checkIfVisible(item, visibleItems) {
+    // 讓初始化的時候直接顯示在畫面上，避免 timeline 會因為不在當前可視時間範圍內而不顯示造成排序的問題。
+    // if (item.isVisible(range)) {
+    if (!item.displayed) item.show();
+    // reposition item horizontally
+    item.repositionX();
+    visibleItems.push(item);
+    // } else {
+    //   if (item.displayed) item.hide();
+    // }
   }
 
   /**


### PR DESCRIPTION
[code review guide](https://github.com/zoeknow/funnow.web.nuxt/wiki/Code-Review-Guide)
## Objective
避免 vis-timeline 因為優化顯示 Item 的邏輯而導致排序不可控制

## Description
1. 移除 vis-timeline 在加入 Item 時候會先略過未在可視時間範圍內的 Item ，優先渲染在範圍內的 Item，造成排序不如預期 [0806033](https://github.com/myfunnow/vis-timeline/pull/1/commits/08060335d72d2e9cab22b976327711c21c7b8beb)
1. 拖曳時間軸時候，會移除不在可視時間範圍內的 Item ，造成排序不如預期。
由於時間關係，先暫時註解掉優化的邏輯，讓所有 Item 在渲染完後一直保持在 DOM tree 上，後續再來規劃優化流程。[0e92105](https://github.com/myfunnow/vis-timeline/pull/1/commits/0e92105d0de4fe2d56b29cd13c47e7e7626cb2aa)

## Test
起一個 Http server 並輸入 http://127.0.0.1:port/examples/timeline/other/usingReact16.html

## ScreenShoot
測試資料應該要如下圖一樣顯示
![image](https://github.com/myfunnow/vis-timeline/assets/12494619/76526574-bee1-4a12-902c-63cbd237d271)

## Checklist
Please make sure to complete the following checklist before merge or remove [WIP]
- [ ] Unit tests (explain in Description if any reasons why it is difficult to write tests, such as adjusting payment API)
- [x] Manual test on local or dev 
- [x] Self review
- [ ] Other things need to check (e.g. i18n / confirm with BE / etc.)
